### PR TITLE
Fix spelling of recipient_name field

### DIFF
--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -16,6 +16,6 @@ class BadgesController < ApplicationController
   private
 
   def submit_badge_form_params
-    params.require(:submit_badge_form).permit(:issue_date, :recipent_name, :uuid)
+    params.require(:submit_badge_form).permit(:issue_date, :recipient_name, :uuid)
   end
 end

--- a/app/forms/submit_badge_form.rb
+++ b/app/forms/submit_badge_form.rb
@@ -1,9 +1,9 @@
 class SubmitBadgeForm
   include ActiveModel::Model
 
-  attr_accessor :issue_date, :recipent_name, :uuid
+  attr_accessor :issue_date, :recipient_name, :uuid
 
-  validates :issue_date, :recipent_name, :uuid, presence: true
+  validates :issue_date, :recipient_name, :uuid, presence: true
   validates :uuid, uuid: true
 
   def save

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -1,5 +1,5 @@
 class Badge < ApplicationRecord
-  validates :recipent_name, presence: true
+  validates :recipient_name, presence: true
   validates :issue_date, presence: true
   validates :uuid, presence: true, uniqueness: true, uuid: true
   validates :proof_id, presence: true, uniqueness: true, uuid: true

--- a/app/views/badges/new.html.erb
+++ b/app/views/badges/new.html.erb
@@ -9,7 +9,7 @@
 
   <br/>
   <div>
-    <%= f.text_field :recipent_name, placeholder: "Badge Recipent name" %>
+    <%= f.text_field :recipient_name, placeholder: "Badge Recipient name" %>
   </div>
 
   <br/>

--- a/db/migrate/20210802220005_rename_recipent_name_to_recipient_name_in_badges_table.rb
+++ b/db/migrate/20210802220005_rename_recipent_name_to_recipient_name_in_badges_table.rb
@@ -1,0 +1,5 @@
+class RenameRecipentNameToRecipientNameInBadgesTable < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :badges, :recipent_name, :recipient_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_02_162837) do
+ActiveRecord::Schema.define(version: 2021_08_02_220005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "badges", force: :cascade do |t|
-    t.string "recipent_name", null: false
+    t.string "recipient_name", null: false
     t.date "issue_date", null: false
     t.uuid "uuid", null: false
     t.uuid "proof_id", null: false

--- a/spec/factories/badge_factory.rb
+++ b/spec/factories/badge_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :badge do
-    recipent_name { 'Jhon' }
+    recipient_name { 'Jhon' }
     issue_date    { 1.day.ago.to_date }
     uuid          { SecureRandom.uuid }
     proof_id      { SecureRandom.uuid }

--- a/spec/features/badges_controller_spec.rb
+++ b/spec/features/badges_controller_spec.rb
@@ -13,7 +13,7 @@ describe 'BadgesController' do
         visit new_badge_path
 
         fill_in 'submit_badge_form_issue_date', with: '21/08/2021'
-        fill_in 'submit_badge_form_recipent_name', with: 'Jhon'
+        fill_in 'submit_badge_form_recipient_name', with: 'Jhon'
         fill_in 'submit_badge_form_uuid', with: 'INVALID_UUID'
 
         click_on 'Submit to Chainpoint'
@@ -29,7 +29,7 @@ describe 'BadgesController' do
         visit new_badge_path
 
         fill_in 'submit_badge_form_issue_date', with: '21/08/2021'
-        fill_in 'submit_badge_form_recipent_name', with: 'Jhon'
+        fill_in 'submit_badge_form_recipient_name', with: 'Jhon'
         fill_in 'submit_badge_form_uuid', with: 'Ia8254e2f-6f05-4ee4-b038-2997553f8a94'
 
         click_on 'Submit to Chainpoint'

--- a/spec/forms/submit_badge_form_spec.rb
+++ b/spec/forms/submit_badge_form_spec.rb
@@ -5,9 +5,9 @@ describe SubmitBadgeForm do
     context 'when form attributes are valid' do
       let(:attributes) do
         {
-          issue_date:    Date.new(2021, 5, 1),
-          recipent_name: 'Jhon',
-          uuid:          SecureRandom.uuid
+          issue_date:     Date.new(2021, 5, 1),
+          recipient_name: 'Jhon',
+          uuid:           SecureRandom.uuid
         }
       end
 
@@ -19,9 +19,9 @@ describe SubmitBadgeForm do
     context 'when form attributes are invalid' do
       let(:attributes) do
         {
-          issue_date:    Date.new(2021, 5, 1),
-          recipent_name: nil,
-          uuid:          SecureRandom.uuid
+          issue_date:     Date.new(2021, 5, 1),
+          recipient_name: nil,
+          uuid:           SecureRandom.uuid
         }
       end
 


### PR DESCRIPTION
This PR:
- renames recipent_name field to recipient_name in badges table