### PR TITLE
Rename badges hash field to chainpoint_hash to resolve conflict with ActiveRecord

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -3,5 +3,5 @@ class Badge < ApplicationRecord
   validates :issue_date, presence: true
   validates :uuid, presence: true, uniqueness: true, uuid: true
   validates :proof_id, presence: true, uniqueness: true, uuid: true
-  validates :hash, presence: true, uniqueness: true
+  validates :chainpoint_hash, presence: true, uniqueness: true
 end

--- a/db/migrate/20210805003152_rename_hash_to_chainpoint_hash_in_badges_table.rb
+++ b/db/migrate/20210805003152_rename_hash_to_chainpoint_hash_in_badges_table.rb
@@ -1,0 +1,5 @@
+class RenameHashToChainpointHashInBadgesTable < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :badges, :hash, :chainpoint_hash
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_02_220005) do
+ActiveRecord::Schema.define(version: 2021_08_05_003152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,11 +20,11 @@ ActiveRecord::Schema.define(version: 2021_08_02_220005) do
     t.date "issue_date", null: false
     t.uuid "uuid", null: false
     t.uuid "proof_id", null: false
-    t.string "hash", null: false
+    t.string "chainpoint_hash", null: false
     t.jsonb "metadata", default: "{}", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["hash"], name: "index_badges_on_hash", unique: true
+    t.index ["chainpoint_hash"], name: "index_badges_on_chainpoint_hash", unique: true
     t.index ["proof_id"], name: "index_badges_on_proof_id", unique: true
     t.index ["uuid"], name: "index_badges_on_uuid", unique: true
   end

--- a/spec/factories/badge_factory.rb
+++ b/spec/factories/badge_factory.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :badge do
-    recipient_name { 'Jhon' }
-    issue_date    { 1.day.ago.to_date }
-    uuid          { SecureRandom.uuid }
-    proof_id      { SecureRandom.uuid }
-    hash          { SecureRandom.hex(32) }
-    metadata      { { hash_received: 1.day.ago } }
+    recipient_name  { 'Jhon' }
+    issue_date      { 1.day.ago.to_date }
+    uuid            { SecureRandom.uuid }
+    proof_id        { SecureRandom.uuid }
+    chainpoint_hash { SecureRandom.hex(32) }
+    metadata        { { hash_received: 1.day.ago } }
   end
 end


### PR DESCRIPTION
This PR:
- renames hash field to chainpoint_hash in badges data table

It turns out that hash is reserved name and using it generates conflicts with ActiveRecord. 